### PR TITLE
Fix watchlist status filters falling out of sync with media

### DIFF
--- a/src/routes/watchlist/+page.svelte
+++ b/src/routes/watchlist/+page.svelte
@@ -6,10 +6,12 @@
 
 	export let data: PageData;
 
+	let list = data.list;
+
 	type Media = PageData['list'] extends readonly (infer ElementType)[] ? ElementType : never;
 
 	let mediaFilters: Map<string, { type: keyof Media; value: string }> = new Map();
-	$: filteredMedia = data.list.filter((m) => {
+	$: filteredMedia = list.filter((m) => {
 		let isValid = true;
 		for (const [_, { type: field, value }] of mediaFilters) {
 			const fieldValue = m[field];
@@ -29,6 +31,14 @@
 
 		return isValid;
 	});
+
+	const handleToggleWatched = (toggledMedia: Media) => {
+		list = list.map((existingMedia) =>
+			existingMedia.tmdbID === toggledMedia.tmdbID && existingMedia.type === toggledMedia.type
+				? toggledMedia
+				: existingMedia
+		);
+	};
 </script>
 
 <div class="p-8">
@@ -36,14 +46,14 @@
 		Your watchlist
 	</h1>
 	<Filter
-		media={data.list ?? []}
+		media={list ?? []}
 		onFilterChange={(s) => {
 			mediaFilters = s;
 		}}
 	/>
 	<div class="flex flex-col gap-4 pt-4 w-full">
 		{#each filteredMedia as media}
-			<MediaRow {media} />
+			<MediaRow {media} onWatchedToggle={handleToggleWatched} />
 		{/each}
 	</div>
 </div>

--- a/src/routes/watchlist/MediaRow.svelte
+++ b/src/routes/watchlist/MediaRow.svelte
@@ -9,7 +9,10 @@
 	import { goto } from '$app/navigation';
 	import { ClapperboardIcon, SearchIcon } from 'lucide-svelte';
 
-	export let media: PageData['list'] extends readonly (infer ElementType)[] ? ElementType : never;
+	type Media = PageData['list'] extends readonly (infer ElementType)[] ? ElementType : never;
+
+	export let media: Media;
+	export let onWatchedToggle: (media: Media) => void;
 
 	let showClapper = false;
 
@@ -30,6 +33,8 @@
 					}, 3500);
 				}
 				isWatched = !isWatched;
+
+				onWatchedToggle({ ...media, isWatched });
 			}
 			isLoading = false;
 		});


### PR DESCRIPTION
Fixes #16.

Added a callback to `<MediaRow />` to update the list of rendered media in the watchlist when media's watch status is toggled